### PR TITLE
Fix for: uncaught exception method 'onmobiledomain' does not exist on 'Security'

### DIFF
--- a/code/MobileSiteTreeExtension.php
+++ b/code/MobileSiteTreeExtension.php
@@ -8,7 +8,7 @@ class MobileSiteTreeExtension extends DataObjectDecorator {
 		$config = SiteConfig::current_site_config();
 
 		// Ensure a canonical link is placed, for semantic correctness and SEO
-		if(Controller::has_curr() && Controller::curr()->onMobileDomain() && $config->MobileSiteType == 'RedirectToDomain') {
+		if(Controller::has_curr() && Controller::curr()->hasMethod("onMobileDomain") && Controller::curr()->onMobileDomain() && $config->MobileSiteType == 'RedirectToDomain') {
 			$oldBaseURL = Director::baseURL();
 			Director::setbaseURL($config->FullSiteDomain);
 			$tags .= sprintf('<link rel="canonical" href="%s" />', $this->owner->AbsoluteLink()) . "\n";


### PR DESCRIPTION
Hi Will and Sean,

On trying out the mobile module I received the following error when trying to access the login page. Tried on a new install of Silverstripe 2.4.5 and Silverstripe-Mobile. Attached change fixes the issue.

[User Error] Uncaught Exception: Object->__call(): the method 'onmobiledomain' does not exist on 'Security'
GET /llantwithub/Security/login?BackURL=%2Fllantwithub%2Fadmin

Line 724 in G:\localhost\llantwithub\sapphire\core\Object.php
Source

715  
716                 default :
717                     throw new Exception (
718                         "Object->__call(): extra method $method is invalid on $this->class:" . var_export($config, true)
719                     );
720             }
721         } else {
722             // Please do not change the exception code number below.
723  
724             throw new Exception("Object->__call(): the method '$method' does not exist on '$this->class'", 2175);
725         }
726     }
727  
728     // -----------------------------------------------------------------------------------------------------------------
729  
730     /**

Trace

```
Object->__call(onMobileDomain,Array)
Security->onMobileDomain()
Line 11 of MobileSiteTreeExtension.php
MobileSiteTreeExtension->MetaTags(<meta name="generator" content="SilverStripe - http://silverstripe.org" /> <meta http-equiv="Content-type" content="text/html; charset=utf-8" /> ,,,,,,)
Line 963 of Object.php
Object->extend(MetaTags,<meta name="generator" content="SilverStripe - http://silverstripe.org" /> <meta http-equiv="Content-type" content="text/html; charset=utf-8" /> )
Line 1256 of SiteTree.php
SiteTree->MetaTags(false)
call_user_func_array(Array,Array)
Line 693 of Object.php
Object->__call(MetaTags,Array)
Page_Controller->MetaTags(false)
call_user_func_array(Array,Array)
Line 369 of ViewableData.php
ViewableData->obj(MetaTags,Array,,1,)
Line 823 of ViewableData.php
ViewableData_Customised->obj(MetaTags,Array,,1,)
Line 823 of ViewableData.php
ViewableData_Customised->obj(MetaTags,Array,,1)
Line 446 of ViewableData.php
ViewableData->XML_val(MetaTags,Array,1)
Line 43 of .cache.themes.blackcandy.templates.Page.ss
include(C:\WINDOWS\Temp\silverstripe-cacheG--localhost-llantwithub\.cache.themes.blackcandy.templates.Page.ss)
Line 429 of SSViewer.php
SSViewer->process(ViewableData_Customised)
Line 342 of ViewableData.php
ViewableData->renderWith(Array)
Line 401 of Security.php
Security->login(SS_HTTPRequest)
Line 193 of Controller.php
Controller->handleAction(SS_HTTPRequest)
Line 143 of RequestHandler.php
RequestHandler->handleRequest(SS_HTTPRequest)
Line 147 of Controller.php
Controller->handleRequest(SS_HTTPRequest)
Line 282 of Director.php
Director::handleRequest(SS_HTTPRequest,Session)
Line 125 of Director.php
Director::direct(/Security/login)
Line 127 of main.php
```
