### PR TITLE
iPad detection option

### DIFF
--- a/code/MobileBrowserDetector.php
+++ b/code/MobileBrowserDetector.php
@@ -23,6 +23,13 @@ class MobileBrowserDetector {
 		return (preg_match('/(ipod|iphone)/i', $_SERVER['HTTP_USER_AGENT'])) ? true : false;
 	}
 
+	// i added 14/1/2011
+	
+	public static function is_ipad() {
+		return (preg_match('/(ipad)/i', $_SERVER['HTTP_USER_AGENT'])) ? true : false;
+	}
+
+	
 	public static function is_opera_mini() {
 		return (stripos($_SERVER['HTTP_USER_AGENT'], 'opera mini') !== false) ? true : false;
 	}

--- a/code/MobileBrowserDetector.php
+++ b/code/MobileBrowserDetector.php
@@ -23,7 +23,6 @@ class MobileBrowserDetector {
 		return (preg_match('/(ipod|iphone)/i', $_SERVER['HTTP_USER_AGENT'])) ? true : false;
 	}
 
-	// i added 14/1/2011
 	
 	public static function is_ipad() {
 		return (preg_match('/(ipad)/i', $_SERVER['HTTP_USER_AGENT'])) ? true : false;

--- a/code/MobileBrowserDetector.php
+++ b/code/MobileBrowserDetector.php
@@ -29,7 +29,7 @@ class MobileBrowserDetector {
 		return (preg_match('/(ipad)/i', $_SERVER['HTTP_USER_AGENT'])) ? true : false;
 	}
 
-	
+
 	public static function is_opera_mini() {
 		return (stripos($_SERVER['HTTP_USER_AGENT'], 'opera mini') !== false) ? true : false;
 	}
@@ -58,6 +58,10 @@ class MobileBrowserDetector {
 		$accept = isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : '';
 
 		switch(true) {
+			case(self::is_ipad()):
+				$isMobile = true;
+				
+				break;
 			case(self::is_iphone()):
 				$isMobile = true;
 				break;

--- a/code/MobileSiteConfigExtension.php
+++ b/code/MobileSiteConfigExtension.php
@@ -37,7 +37,7 @@ class MobileSiteConfigExtension extends DataObjectDecorator {
 				'MobileDomain' => 'Varchar(50)',
 				'FullSiteDomain' => 'Varchar(50)',
 				'MobileTheme' => 'Varchar(255)',
-				//added 14/1/2011
+		
 				'Ipadtheme' => 'Varchar(255)',
 				'MobileSiteType' => 'Enum("Disabled,RedirectToDomain,MobileThemeOnly","Disabled")',
 			),
@@ -45,7 +45,6 @@ class MobileSiteConfigExtension extends DataObjectDecorator {
 				'MobileDomain' => 'http://m.' . $_SERVER['HTTP_HOST'],
 				'FullSiteDomain' => 'http://' . $_SERVER['HTTP_HOST'],
 				'MobileTheme' => 'blackcandymobile',
-				//added 14/1/2011
 				'Ipadtheme' => 'testipad',
 				'MobileSiteType' => 'Disabled'
 			)

--- a/code/MobileSiteConfigExtension.php
+++ b/code/MobileSiteConfigExtension.php
@@ -37,12 +37,16 @@ class MobileSiteConfigExtension extends DataObjectDecorator {
 				'MobileDomain' => 'Varchar(50)',
 				'FullSiteDomain' => 'Varchar(50)',
 				'MobileTheme' => 'Varchar(255)',
+				//added 14/1/2011
+				'Ipadtheme' => 'Varchar(255)',
 				'MobileSiteType' => 'Enum("Disabled,RedirectToDomain,MobileThemeOnly","Disabled")',
 			),
 			'defaults' => array(
 				'MobileDomain' => 'http://m.' . $_SERVER['HTTP_HOST'],
 				'FullSiteDomain' => 'http://' . $_SERVER['HTTP_HOST'],
 				'MobileTheme' => 'blackcandymobile',
+				//added 14/1/2011
+				'Ipadtheme' => 'testipad',
 				'MobileSiteType' => 'Disabled'
 			)
 		);
@@ -164,6 +168,9 @@ class MobileSiteConfigExtension extends DataObjectDecorator {
 				new TextField('MobileDomain', _t('MobileSiteConfig.MOBILEDOMAIN', 'Mobile domain <small>(e.g. m.mysite.com, needs to be different from "Full site domain")</small>')),
 				new TextField('FullSiteDomain', _t('MobileSiteConfig.FULLSITEDOMAIN', 'Full site domain <small>(e.g. mysite.com, usually doesn\'t need to be changed)</small>')),
 				new DropdownField('MobileTheme', _t('MobileSiteConfig.MOBILETHEME', 'Mobile theme'), $this->owner->getAvailableThemes(), '', null, _t('SiteConfig.DEFAULTTHEME', '(Use default theme)'))
+				/* lee added this 14/1/2011 to add ipad drop down field   */
+				new DropdownField('Ipadtheme', _t('MobileSiteConfig.IPADTHEME', 'ipad theme'), $this->owner->getAvailableThemes(), '', null, _t('SiteConfig.DEFAULTTHEME', '(Use default theme)'))
+
 			)
 		);
 	}

--- a/code/MobileSiteControllerExtension.php
+++ b/code/MobileSiteControllerExtension.php
@@ -90,6 +90,13 @@ class MobileSiteControllerExtension extends Extension {
 			self::$is_mobile = true;
 		}
 
+		//I added 14/1/2011 to detect ipad and send to theme
+		
+		if(MobileBrowserDetector::is_mobile() && $config->MobileSiteType == 'MobileThemeOnly') {
+			if(MobileBrowserDetector::is_ipad())		
+				SSViewer::set_theme($config->Ipadtheme);
+		}
+
 		// If on a mobile device, but not on the mobile domain and has been setup for redirection
 		if(!$this->onMobileDomain() && MobileBrowserDetector::is_mobile() && $config->MobileSiteType == 'RedirectToDomain') {
 			return $this->owner->redirect($config->MobileDomain, 301);

--- a/code/MobileSiteControllerExtension.php
+++ b/code/MobileSiteControllerExtension.php
@@ -90,7 +90,6 @@ class MobileSiteControllerExtension extends Extension {
 			self::$is_mobile = true;
 		}
 
-		//I added 14/1/2011 to detect ipad and send to theme
 		
 		if(MobileBrowserDetector::is_mobile() && $config->MobileSiteType == 'MobileThemeOnly') {
 			if(MobileBrowserDetector::is_ipad())		


### PR DESCRIPTION
I have taken the modification i made to the 0.3 mobile module last year and updated this version.  I only found it today.

I had seen an issue from Sminee https://github.com/silverstripe/silverstripe-mobile/issues/13.

I thought this might help things along.

I have it working with several different sites in the south lakes.  You can see one http://warbirdsandwheels.co.nz here

Feel free to contact me I'm doing heaps of mobile sites(iPad, iPhone, android, tablet, etc) if i can help more than this