### PR TITLE
API Allow declaring multiple domains

### DIFF
--- a/code/MobileSiteConfigExtension.php
+++ b/code/MobileSiteConfigExtension.php
@@ -32,8 +32,10 @@ class MobileSiteConfigExtension extends DataExtension {
 	 * Extra statics variable to merge into {@link SiteConfig}
 	 */
 	static $db = array(
-		'MobileDomain' => 'Varchar(50)',
-		'FullSiteDomain' => 'Varchar(50)',
+		// Comma-separated list of mobile domains, without protocol
+		'MobileDomain' => 'Text',
+		// Comma-separated list of non-mobile domains, without protocol
+		'FullSiteDomain' => 'Text',
 		'MobileTheme' => 'Varchar(255)',
 		'MobileSiteType' => 'Enum("Disabled,RedirectToDomain,MobileThemeOnly","Disabled")'
 	);
@@ -47,8 +49,8 @@ class MobileSiteConfigExtension extends DataExtension {
 	static function add_to_class($class, $extensionClass, $args = null) {
 		if($class == 'SiteConfig') {
 			Config::inst()->update($class, 'defaults', array(
-				'MobileDomain' => 'http://m.' . $_SERVER['HTTP_HOST'],
-				'FullSiteDomain' => 'http://' . $_SERVER['HTTP_HOST']
+				'MobileDomain' => 'm.' . $_SERVER['HTTP_HOST'],
+				'FullSiteDomain' => $_SERVER['HTTP_HOST']
 			));
 		}
 		parent::add_to_class($class, $extensionClass, $args);
@@ -56,41 +58,25 @@ class MobileSiteConfigExtension extends DataExtension {
 
 
 	/**
-	 * Check whether the protocol was specified for the mobile domain,
-	 * and if it wasn't, then assume http. e.g. "mysite.com" => "http://mysite.com"
-	 * 
-	 * @return string
+	 * @return String The first available domain, with the current protocol prefixed,
+	 * suitable for redirections etc.
 	 */
-	public function getMobileDomain() {
-		$defaults = $this->owner->stat('defaults');
-
-		$value = $this->owner->getField('MobileDomain');
-		if(!$value) $value = $defaults['MobileDomain'];
-
-		if(strpos($value, '://') === false) {
-			return 'http://' . $value;
-		} else {
-			return $value;
-		}
+	public function getMobileDomainNormalized() {
+		$domains = explode(',', $this->owner->MobileDomain);
+		$domain = array_shift($domains);
+		if(!parse_url($domain, PHP_URL_SCHEME)) $domain = Director::protocol() . $domain;
+		return $domain;
 	}
 
 	/**
-	 * Check whether the protocol was specified for the full site domain,
-	 * and if it wasn't, then assume http. e.g. "mysite.com" => "http://mysite.com"
-	 * 
-	 * @return string
+	 * @return String The first available domain, with the current protocol prefixed,
+	 * suitable for redirections etc.
 	 */
-	public function getFullSiteDomain() {
-		$defaults = $this->owner->stat('defaults');
-
-		$value = $this->owner->getField('FullSiteDomain');
-		if(!$value) $value = $defaults['FullSiteDomain'];
-
-		if(strpos($value, '://') === false) {
-			return 'http://' . $value;
-		} else {
-			return $value;
-		}
+	public function getFullSiteDomainNormalized() {
+		$domains = explode(',', $this->owner->FullSiteDomain);
+		$domain = array_shift($domains);
+		if(!parse_url($domain, PHP_URL_SCHEME)) $domain = Director::protocol() . $domain;
+		return $domain;
 	}
 
 	/**

--- a/tests/MobileSiteConfigExtensionTest.php
+++ b/tests/MobileSiteConfigExtensionTest.php
@@ -28,13 +28,13 @@ class MobileSiteConfigExtensionTest extends SapphireTest {
 	public function testMobileDomainGetterAddsProtocolPrefix() {
 		$config = SiteConfig::current_site_config();
 		$config->MobileDomain = 'mobile.mysite.com';
-		$this->assertEquals('http://mobile.mysite.com', $config->MobileDomain);
+		$this->assertEquals('http://mobile.mysite.com', $config->MobileDomainNormalized);
 	}
 
 	public function testFullSiteDomainGetterAddsProtocolPrefix() {
 		$config = SiteConfig::current_site_config();
 		$config->FullSiteDomain = 'mysite.com';
-		$this->assertEquals('http://mysite.com', $config->FullSiteDomain);
+		$this->assertEquals('http://mysite.com', $config->FullSiteDomainNormalized);
 	}
 
 	public function tearDown() {

--- a/tests/MobileSiteControllerExtensionTest.php
+++ b/tests/MobileSiteControllerExtensionTest.php
@@ -69,7 +69,7 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 			$_SERVER['HTTP_USER_AGENT'] = $agent;
 			$response = $this->get($page->URLSegment);
 			$headers = $response->getHeaders();
-			$this->assertEquals(302, $response->getStatusCode());
+			$this->assertEquals(301, $response->getStatusCode());
 			$this->assertEquals('http://m.' . $_SERVER['HTTP_HOST'], $headers['Location']);
 		}
 	}
@@ -83,7 +83,7 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$_SERVER['HTTP_ACCEPT'] = 'text/vnd.wap.wml';
 		$response = $this->get($page->URLSegment);
 		$headers = $response->getHeaders();
-		$this->assertEquals(302, $response->getStatusCode());
+		$this->assertEquals(301, $response->getStatusCode());
 		$this->assertEquals('http://m.' . $_SERVER['HTTP_HOST'], $headers['Location']);
 	}
 
@@ -96,7 +96,7 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$_SERVER['HTTP_X_WAP_PROFILE'] = 1;
 		$response = $this->get($page->URLSegment);
 		$headers = $response->getHeaders();
-		$this->assertEquals(302, $response->getStatusCode());
+		$this->assertEquals(301, $response->getStatusCode());
 		$this->assertEquals('http://m.' . $_SERVER['HTTP_HOST'], $headers['Location']);
 		unset($_SERVER['HTTP_X_WAP_PROFILE']);
 	}
@@ -120,8 +120,8 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$_SERVER['HTTP_HOST'] = 'm.' . $_SERVER['HTTP_HOST'];
 		$response = $this->get($page->URLSegment . '?fullSite=1', null, null, array('fullSite' => 1));
 		$headers = $response->getHeaders();
-		$this->assertEquals(302, $response->getStatusCode());
-		$this->assertEquals($config->FullSiteDomain, $headers['Location']);
+		$this->assertEquals(301, $response->getStatusCode());
+		$this->assertEquals($config->FullSiteDomainNormalized, $headers['Location']);
 	}
 
 	public function testRedirectToMobileSiteFromDesktop() {
@@ -131,8 +131,8 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$page = $this->objFromFixture('Page', 'page');
 		$response = $this->get($page->URLSegment . '?fullSite=0', null, null, array('fullSite' => 0));
 		$headers = $response->getHeaders();
-		$this->assertEquals(302, $response->getStatusCode());
-		$this->assertEquals($config->MobileDomain, $headers['Location']);
+		$this->assertEquals(301, $response->getStatusCode());
+		$this->assertEquals($config->MobileDomainNormalized, $headers['Location']);
 	}
 
 	public function testNoMobileRedirectWhenFullSiteSessionSetOnMobile() {
@@ -151,6 +151,20 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$controller = new ContentController();
 		$this->assertFalse($controller->onMobileDomain());
 		$_SERVER['HTTP_HOST'] = 'm.' . $_SERVER['HTTP_HOST'];
+		$this->assertTrue($controller->onMobileDomain());
+	}
+
+	public function testOnMobileSiteMultipleDomains() {
+		$config = SiteConfig::current_site_config();
+		$config->FullSiteDomain = 'domain1.com,domain2.com';
+		$config->MobileDomain = 'm.domain1.com,m.domain2.com';
+		$config->write();
+		$_SERVER['HTTP_HOST'] = 'domain1.com';
+		$controller = new ContentController();
+		$this->assertFalse($controller->onMobileDomain());
+		$_SERVER['HTTP_HOST'] = 'm.domain1.com';
+		$this->assertTrue($controller->onMobileDomain());
+		$_SERVER['HTTP_HOST'] = 'm.domain2.com';
 		$this->assertTrue($controller->onMobileDomain());
 	}
 


### PR DESCRIPTION
The MobileDomain and FullSiteDomain database columns now
accept a comma-separated list of values. This enables developers
to serve mobile content under multiple domains,
which is for example useful when used along the "subsites" module.
It is still recommended to have one canonical URL endpoint
for a unique content collection, though.
