### PR TITLE
FEATURE Ability to disable theme copy on dev/build

### DIFF
--- a/code/MobileSiteConfigExtension.php
+++ b/code/MobileSiteConfigExtension.php
@@ -15,6 +15,8 @@ class MobileSiteConfigExtension extends DataExtension {
 	 * @var string
 	 */
 	protected static $theme_copy_path;
+	
+	public static $theme_copy_enabled = true;
 
 	public static function set_theme_copy_path($path) {
 		self::$theme_copy_path = $path;
@@ -120,6 +122,7 @@ class MobileSiteConfigExtension extends DataExtension {
 	 * @param String
 	 */
 	public static function copyDefaultTheme($theme = null) {
+		if(!self::$theme_copy_enabled) return;
 		if(!$theme) $theme = 'blackcandymobile';
 		$src = '../' . MOBILE_DIR . '/themes/' . $theme;
 		$dst = self::get_theme_copy_path();


### PR DESCRIPTION
Every dev/build the mobile module attempts to copy the blackcandymobile theme into the /themes directory.

I prefer to use a single responsive theme for mobile development, but I still use this module for mobile detection. Hence, having this redundant theme forcing its way into my project's working directory is aggravating.

To disable this behaviour with the attached code simply add the following snippet to your _config.php file

```php
MobileSiteConfigExtension::$theme_copy_enabled = false;
```

Please let this option be a thing!