### PR TITLE
API Allow declaring multiple domains

### DIFF
--- a/tests/MobileSiteConfigExtensionTest.php
+++ b/tests/MobileSiteConfigExtensionTest.php
@@ -28,13 +28,13 @@ class MobileSiteConfigExtensionTest extends SapphireTest {
 	public function testMobileDomainGetterAddsProtocolPrefix() {
 		$config = SiteConfig::current_site_config();
 		$config->MobileDomain = 'mobile.mysite.com';
-		$this->assertEquals('http://mobile.mysite.com', $config->MobileDomain);
+		$this->assertEquals('http://mobile.mysite.com', $config->MobileDomainNormalized);
 	}
 
 	public function testFullSiteDomainGetterAddsProtocolPrefix() {
 		$config = SiteConfig::current_site_config();
 		$config->FullSiteDomain = 'mysite.com';
-		$this->assertEquals('http://mysite.com', $config->FullSiteDomain);
+		$this->assertEquals('http://mysite.com', $config->FullSiteDomainNormalized);
 	}
 
 	public function tearDown() {

--- a/tests/MobileSiteControllerExtensionTest.php
+++ b/tests/MobileSiteControllerExtensionTest.php
@@ -121,7 +121,7 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$response = $this->get($page->URLSegment . '?fullSite=1', null, null, array('fullSite' => 1));
 		$headers = $response->getHeaders();
 		$this->assertEquals(302, $response->getStatusCode());
-		$this->assertEquals($config->FullSiteDomain, $headers['Location']);
+		$this->assertEquals($config->FullSiteDomainNormalized, $headers['Location']);
 	}
 
 	public function testRedirectToMobileSiteFromDesktop() {
@@ -132,7 +132,7 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$response = $this->get($page->URLSegment . '?fullSite=0', null, null, array('fullSite' => 0));
 		$headers = $response->getHeaders();
 		$this->assertEquals(302, $response->getStatusCode());
-		$this->assertEquals($config->MobileDomain, $headers['Location']);
+		$this->assertEquals($config->MobileDomainNormalized, $headers['Location']);
 	}
 
 	public function testNoMobileRedirectWhenFullSiteSessionSetOnMobile() {
@@ -151,6 +151,20 @@ class MobileSiteControllerExtensionTest extends FunctionalTest {
 		$controller = new ContentController();
 		$this->assertFalse($controller->onMobileDomain());
 		$_SERVER['HTTP_HOST'] = 'm.' . $_SERVER['HTTP_HOST'];
+		$this->assertTrue($controller->onMobileDomain());
+	}
+
+	public function testOnMobileSiteMultipleDomains() {
+		$config = SiteConfig::current_site_config();
+		$config->FullSiteDomain = 'domain1.com,domain2.com';
+		$config->MobileDomain = 'm.domain1.com,m.domain2.com';
+		$config->write();
+		$_SERVER['HTTP_HOST'] = 'domain1.com';
+		$controller = new ContentController();
+		$this->assertFalse($controller->onMobileDomain());
+		$_SERVER['HTTP_HOST'] = 'm.domain1.com';
+		$this->assertTrue($controller->onMobileDomain());
+		$_SERVER['HTTP_HOST'] = 'm.domain2.com';
 		$this->assertTrue($controller->onMobileDomain());
 	}
 


### PR DESCRIPTION
The MobileDomain and FullSiteDomain database columns now
accept a comma-separated list of values. This enables developers
to serve mobile content under multiple domains,
which is for example useful when used along the "subsites" module.
It is still recommended to have one canonical URL endpoint
for a unique content collection, though.

Note: This was a required feature for YHA, hence the pull
request is against the 2.4 version of the mobile module.
Should be easily portable to master though.
