### PR TITLE
odified is_mobile to cache previously detection result because device ty...

### DIFF
--- a/code/MobileBrowserDetector.php
+++ b/code/MobileBrowserDetector.php
@@ -62,9 +62,14 @@ class MobileBrowserDetector {
 	 * @return bool
 	 */
 	public static function is_mobile($agent = null) {
+	  //return true;
 		$isMobile = false;
+       if (isset($_GET['flush']))
+         Session::clear('isMobile');  //makes sure session cache is cleared when flush is requested 
+        $isMobile=Session::get('isMobile');
+       if (!$isMobile&&$isMobile!==0){   
 		if(!$agent) $agent = $_SERVER['HTTP_USER_AGENT'];
-		$accept = isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : '';
+		   $accept = isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : '';
 
 		switch(true) {
 			case(self::is_iphone()):
@@ -101,11 +106,14 @@ class MobileBrowserDetector {
 				$isMobile = true;
 				break;
 		}
-
+		if (!$isMobile) $isMobile=0;
+          Session::set('isMobile', $isMobile);   
+     } 
 		if(!headers_sent()) {
 			header('Cache-Control: no-transform');
 			header('Vary: User-Agent, Accept');
 		}
+     
 
 		return $isMobile;
 	}


### PR DESCRIPTION
modified is_mobile() function to cache the result of detection because
device type will not change during session. it makes sure the result whether device is mobile or not is checked only once during session, reducing extra overkill. Whenever, is_mobile is called, before going to check headers, user agent etc to see whether it is mobile what type is it, it just returns the existing result because this device just made a request and was detected. 
