### PR TITLE
FIX: Perform DB build instead of requireDefaultRecords()

### DIFF
--- a/tests/MobileSiteConfigExtensionTest.php
+++ b/tests/MobileSiteConfigExtensionTest.php
@@ -6,15 +6,15 @@
 class MobileSiteConfigExtensionTest extends SapphireTest {
 
 	public function setUp() {
-		parent::setUp();
 		MobileSiteConfigExtension::set_theme_copy_path(TEMP_FOLDER . '/mobile-test-copy-theme/');
+		parent::setUp();
 	}
 
 	public function testRequireDefaultRecordsCopiesDefaultThemeWhenDefaultThemeSet() {
 		$config = SiteConfig::current_site_config();
 		$config->MobileTheme = 'blackcandymobile';
 		$config->write();
-		$config->requireDefaultRecords();
+
 		$this->assertTrue(file_exists(TEMP_FOLDER . '/mobile-test-copy-theme/'));
 	}
 


### PR DESCRIPTION
augmentDatabase() is now used on MobileSiteConfigExtension to copy the
theme, instead of requireDefaultRecords(). This means we need to do a
dev/build internally to have the theme copied.
